### PR TITLE
Resize the admin console buttons to take the minimum horizontal space

### DIFF
--- a/portal/app/static/css/admin-console.css
+++ b/portal/app/static/css/admin-console.css
@@ -178,8 +178,6 @@
 }
 
 .sub-section {
-
-    display: block;
   margin-left: auto;
   margin-right: auto;
     text-align: center;

--- a/portal/app/static/css/main-style.css
+++ b/portal/app/static/css/main-style.css
@@ -1,6 +1,9 @@
 #content {
     min-height: 100%;
     padding-bottom: 50px;
+
+    display: flex;
+    flex-direction: column;
 }
 
 * {


### PR DESCRIPTION
This pull-request is made to fix issue #112

The class .sub-section used to style the buttons had the “display: block;” property, which made the buttons take all the horizontal space.

By removing this property, the buttons will only take the minimum space.

Then adding the properties “display: flex;” and “flex-direction: column;” to the #content css ruleset to align all the elements like before. This will not affect other pages, as the behavior of the elements placement still the same

![ezgif-5-f106cf6dbf](https://github.com/claytonmsafranek/UNO-CSLC-Ticket-Portal/assets/100537067/4b165ff2-2108-47ec-906c-450b60bc78bb)
