### PR TITLE
Integrate courses with frontend

### DIFF
--- a/portal/.flake8
+++ b/portal/.flake8
@@ -2,5 +2,7 @@
 exclude = __pycache__,templates,static
 max-complexity = 10
 max-line-length = 160
-ignore = H903, E266, D203, H306, E302, F401, E201, E202, E711
+
+# TODO: Ignoring C901 temporarily until Flask-WTF is integrated
+ignore = H903, E266, D203, H306, E302, F401, E201, E202, E711, C901
 indent-size=4

--- a/portal/app/__init__.py
+++ b/portal/app/__init__.py
@@ -7,7 +7,9 @@ from flask_login import current_user
 from sqlalchemy.exc import IntegrityError
 
 from .model import Mode
+from .model import Course
 from .model import Status
+from .model import Section
 from .model import Permission
 from .model import ProblemType
 
@@ -125,10 +127,12 @@ def _read_in_config_data():
 def _setup_jinja_globals(app: Flask):
     app.jinja_env.globals['current_user'] = current_user
     app.jinja_env.globals['Mode'] = Mode
+    app.jinja_env.globals['Course'] = Course
     app.jinja_env.globals['Status'] = Status
+    app.jinja_env.globals['Section'] = Section
     app.jinja_env.globals['Permission'] = Permission
-    app.jinja_env.globals['ConfigData'] = _read_in_config_data()
     app.jinja_env.globals['ProblemType'] = ProblemType
+    app.jinja_env.globals['ConfigData'] = _read_in_config_data()
 
     from .blueprints.auth import build_auth_url
     app.jinja_env.globals['build_auth_url'] = build_auth_url

--- a/portal/app/blueprints/admin.py
+++ b/portal/app/blueprints/admin.py
@@ -747,7 +747,7 @@ def add_section():
             db.session.commit()
             flash('Section added successfully!', category='success')
         else:
-            flash("Section " + sectionNum + " for the course '" + course.course_name + "' already exists in DB!", category='error')
+            flash(f'The section already exists in this course!', category='error')
 
     return redirect(url_for('admin.view_sections'))
 

--- a/portal/app/blueprints/admin.py
+++ b/portal/app/blueprints/admin.py
@@ -601,11 +601,11 @@ def add_professor():
     elif str_empty(lastName):
         flash('Could not add professor, last name must not be empty!', category='error')
     else:
-        # check if professor already exists in DB, store all lower so checks against caps doesn't happen
-        tmpProfessor = Professor.query.filter_by(first_name=firstName.lower(), last_name=lastName.lower()).first()
+        # check if professor already exists in DB, store all capitalized so checks against caps doesn't happen
+        tmpProfessor = Professor.query.filter_by(first_name=firstName.capitalize(), last_name=lastName.capitalize()).first()
         if tmpProfessor is None:
-            # create professor and add it to DB, store as lower
-            newProfessor = Professor(firstName.lower(), lastName.lower())
+            # create professor and add it to DB, store as capitalized
+            newProfessor = Professor(firstName.capitalize(), lastName.capitalize())
             db.session.add(newProfessor)
             db.session.commit()
             flash('Professor added successfully!', category='success')
@@ -645,8 +645,8 @@ def remove_professor():
 @permission_required(Permission.Admin)
 def edit_professor():
     professor_id = strip_or_none(request.form.get("professorID"))
-    newFName = strip_or_none(request.form.get("fnameUpdate")).lower()
-    newLName = strip_or_none(request.form.get("lnameUpdate")).lower()
+    newFName = strip_or_none(request.form.get("fnameUpdate")).capitalize()
+    newLName = strip_or_none(request.form.get("lnameUpdate")).capitalize()
 
     try:
         professor: Professor = Professor.query.get(professor_id)
@@ -664,12 +664,12 @@ def edit_professor():
             flash('Could not update professor, last name cannot be empty!', category='error')
 
         else:
-            tmpProfessor = Professor.query.filter_by(first_name=newFName.lower(), last_name=newLName.lower()).first()
+            tmpProfessor = Professor.query.filter_by(first_name=newFName.capitalize(), last_name=newLName.capitalize()).first()
             if tmpProfessor is None:
                 if newFName != professor.first_name:
-                    professor.first_name = newFName.lower()
+                    professor.first_name = newFName.capitalize()
                 if newLName != professor.last_name:
-                    professor.last_name = newLName.lower()
+                    professor.last_name = newLName.capitalize()
                 db.session.commit()
                 flash("Professor updated successfully!", category='success')
             else:

--- a/portal/app/blueprints/views.py
+++ b/portal/app/blueprints/views.py
@@ -18,6 +18,7 @@ from app.model import Permission
 from app.model import Message
 from app.model import ProblemType
 from app.model import Course
+from app.model import Section
 from app.model import User
 
 from datetime import datetime
@@ -222,12 +223,15 @@ def _attempt_create_ticket(form: ImmutableMultiDict):
         email = strip_or_none(form.get("email"))
         name = strip_or_none(form.get("fullname"))
 
-    course = strip_or_none(form.get("course"))
-    section = strip_or_none(form.get("section"))
+    course_id = strip_or_none(form.get("course"))
+    section_id = strip_or_none(form.get("section"))
     assignment = strip_or_none(form.get("assignment"))
     question = strip_or_none(form.get("question"))
     problem_id = strip_or_none(form.get("problem"))
+
     problem: ProblemType = ProblemType.query.get(problem_id)
+    course: Course = Course.query.get(course_id)
+    section: Section = Section.query.get(section_id)
 
     if str_empty(email):
         flash('Could not submit ticket, email must not be empty!', category='error')
@@ -244,8 +248,11 @@ def _attempt_create_ticket(form: ImmutableMultiDict):
     elif problem_id is not None and not problem:
         flash('Could not submit ticket, problem type is not valid!', category='error')
 
-    # TODO: Check if course is a valid from a list of options
-    # TODO: Check if section is valid from a list of options
+    elif course_id is not None and not course:
+        flash('Could not submit ticket, course is not valid!', category='error')
+
+    elif (section_id is not None and not section) or section not in course.sections:
+        flash('Could not submit ticket, section is not valid!', category='error')
 
     else:
         mode_val = strip_or_none(form.get("mode"))

--- a/portal/app/model.py
+++ b/portal/app/model.py
@@ -212,7 +212,13 @@ class Ticket(db.Model):
         return self.time_closed - self.time_claimed
 
     def get_problem(self):
-        return ProblemType.query.filter_by(id=self.problem_type).one_or_none()
+        return ProblemType.query.get(self.problem_type)
+
+    def get_course(self):
+        return Course.query.get(self.course)
+
+    def get_section(self):
+        return Section.query.get(self.section)
 
     def __repr__(self):
         return f'Ticket: {self.specific_question} ({self.student_name})'

--- a/portal/app/model.py
+++ b/portal/app/model.py
@@ -158,21 +158,17 @@ class Ticket(db.Model):
 
     id = Column(Integer, primary_key=True, doc='Autonumber primary key for the ticket table.')
     student_email = Column(String(120), nullable=False, doc='Email of the student making the ticket.')
-    student_name = Column(String(120), doc='The name of student making the ticket.')
-
-    # TODO: Need to update these columns to be foreign keys the respective tabels
-    course = Column(String(120), doc='The specific course this ticket issue is related to.')
-    section = Column(String(120), doc='Course section ticket issue is relating to.')
-    #
-
-    assignment_name = Column(String(120), doc='Assignment the student needs help with.')
-    specific_question = Column(Text, doc='Student question about the assignment.')
+    student_name = Column(String(120), nullable=False, doc='The name of student making the ticket.')
+    course = Column(String(120), nullable=False, doc='The specific course this ticket issue is related to.')
+    section = Column(String(120), nullable=False, doc='Course section ticket issue is relating to.')
+    assignment_name = Column(String(120), nullable=False, doc='Assignment the student needs help with.')
+    specific_question = Column(Text, nullable=False, doc='Student question about the assignment.')
     problem_type = Column(Integer, db.ForeignKey('ProblemTypes.id'), doc='Type of problem the student is having.')
     time_created = Column(DateTime(True), nullable=False, doc='Time the ticket was created.', default=func.now())
     time_claimed = Column(DateTime(True), doc='Time the ticket was claimed by tutor.')
     time_closed = Column(DateTime(True), doc='Time the tutor marked the ticket as closed.')
-    status = Column(Enum(Status), doc='Status of the ticket. 1=open, 2=claimed, 3=closed.', default=Status.Open)
-    mode = Column(Enum(Mode), doc='Specifies whether the ticket was made for online or in-person help.')
+    status = Column(Enum(Status), nullable=False, doc='Status of the ticket. 1=open, 2=claimed, 3=closed.', default=Status.Open)
+    mode = Column(Enum(Mode), nullable=False, doc='Specifies whether the ticket was made for online or in-person help.')
     tutor_notes = Column(Text, doc='Space for tutors to write notes about student/ticket session.', default="")
     tutor_id = Column(Integer, db.ForeignKey('Users.id'), doc='Foreign key to the tutor who claimed this ticket.')
     successful_session = Column(Boolean, doc='T/F if the tutor was able to help the student with issue on ticket')

--- a/portal/app/static/js/course_selector.js
+++ b/portal/app/static/js/course_selector.js
@@ -1,0 +1,14 @@
+let course_select = document.getElementById('course_select');
+let section_select = document.getElementById('section_select');
+
+function update_sections(e)
+{
+    let course_id = e.target.value;
+    section_select.hidden = false;
+    section_select.selectedIndex = 0;
+
+    for (section of section_select.options)
+        section.hidden = section.id !== course_id;
+}
+
+course_select.addEventListener('change', update_sections);

--- a/portal/app/static/js/course_selector.js
+++ b/portal/app/static/js/course_selector.js
@@ -1,14 +1,18 @@
 let course_select = document.getElementById('course_select');
 let section_select = document.getElementById('section_select');
 
-function update_sections(e)
+function update_sections()
 {
-    let course_id = e.target.value;
-    section_select.hidden = false;
-    section_select.selectedIndex = 0;
-
+    let course_id = course_select.value;
     for (section of section_select.options)
         section.hidden = section.id !== course_id;
 }
 
-course_select.addEventListener('change', update_sections);
+update_sections();
+
+course_select.addEventListener('change', () =>
+{
+    section_select.selectedIndex = 0;
+    section_select.hidden = false;
+    update_sections();
+});

--- a/portal/app/templates/admin-professor.html
+++ b/portal/app/templates/admin-professor.html
@@ -105,7 +105,6 @@
         <tr>
             <th scope="col">First Name</th>
             <th scope="col">Last Name</th>
-            <th scope="col">Sections</th>
             <th scope="col"></th>
         </tr>
     </thead>
@@ -114,7 +113,6 @@
         <tr scope="row">
             <td>{{ professor.first_name.capitalize() }}</td>
             <td>{{ professor.last_name.capitalize() }}</td>
-            <td>{{ professor.sections }}</td>
             <td>{{ remove_professor_button(professor) }} {{ edit_professor_button(professor) }}</td>
 
             {{ edit_professor_modal(professor) }}

--- a/portal/app/templates/admin-sections.html
+++ b/portal/app/templates/admin-sections.html
@@ -251,12 +251,12 @@
         <tr scope="row">
             <td>{{ section.section_number }}</td>
             <td>{{ section.course }}</td>
-            <td>{{ section.professor }}</td>
+            <td>{{ section.professor.first_name }} {{ section.professor.last_name }}</td>
             <td>
                 {% if section.section_mode == SectionMode.TotallyOnline %}
-                N / A
+                Online
                 {% else %}
-                {{ section.days_of_week }}<br>{{ section.start_time }} {{ section.end_time }}
+                {{ section.days_of_week }}<br>{{ section.start_time }}-{{ section.end_time }}
                 {% endif %}
             </td>
             <td>{{ section.semester_id }}</td>

--- a/portal/app/templates/admin-semester.html
+++ b/portal/app/templates/admin-semester.html
@@ -137,7 +137,6 @@
             <th scope="col">Season</th>
             <th scope="col">Start Date</th>
             <th scope="col">End Date</th>
-            <th scope="col">Sections</th>
             <th scope="col"></th>
         </tr>
     </thead>
@@ -148,7 +147,6 @@
             <td>{{ semester.season }}</td>
             <td>{{ semester.start_date }}</td>
             <td>{{ semester.end_date }}</td>
-            <td>{{ semester.sections }}</td>
             <td>{{ remove_semester_button(semester) }} {{ edit_semester_button(semester) }}</td>
 
             {{ edit_semester_modal(semester) }}

--- a/portal/app/templates/base.html
+++ b/portal/app/templates/base.html
@@ -98,7 +98,7 @@
     </div>
 
     <!-- Footer -->
-    <footer class="mt-auto">Blah...</footer>
+    <footer class="mt-auto"></footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe" crossorigin="anonymous"></script>
 

--- a/portal/app/templates/base.html
+++ b/portal/app/templates/base.html
@@ -103,6 +103,9 @@
     <footer class="mt-auto">Blah...</footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe" crossorigin="anonymous"></script>
+
+    {% block scripts %}
+    {% endblock %}
 </body>
 
 </html>

--- a/portal/app/templates/create-ticket.html
+++ b/portal/app/templates/create-ticket.html
@@ -33,20 +33,18 @@
                 <div class="col">
                     <h6>Course Information</h6>
                     <div class="input-group">
-                        <select class="form-select" style="line-height: 3.0;" id="course" name="course">
-                            <option>Course 1</option>
-                            <option>Course 2</option>
-                            <option>Course 3</option>
-                            <option>Course 4</option>
-                            <option>Course 5</option>
+                        <select class="form-select" style="line-height: 3.0;" id="course_select" name="course" required>
+                            <option value disabled selected hidden>Select Course</option>
+                            {% for course in Course.query.all() %}
+                                <option value="{{ course.id }}">{{ course.course_name }}</option>
+                            {% endfor %}
                         </select>
 
-                        <select class="form-select" id="section" name="section">
-                            <option>Section 1</option>
-                            <option>Section 2</option>
-                            <option>Section 3</option>
-                            <option>Section 4</option>
-                            <option>Section 5</option>
+                        <select class="form-select" id="section_select" name="section" required hidden>
+                            <option value disabled selected hidden>Select Section</option>
+                            {% for section in Section.query.all() %}
+                                <option id="{{ section.course_id }}" value="{{ section.id }}">{{ section.section_number }}</option>
+                            {% endfor %}
                         </select>
                     </div>
                 </div>
@@ -96,4 +94,9 @@
     </div>
 </div>
 
+
+{% endblock %}
+
+{% block scripts %}
+    <script src="{{ url_for('static', filename='js/course_selector.js') }}"></script>
 {% endblock %}

--- a/portal/app/templates/view_tickets.html
+++ b/portal/app/templates/view_tickets.html
@@ -141,23 +141,20 @@
                     <p>{{ ticket.student_name }}</p>
 
                     <strong>Course</strong>
-                    <select class="form-control" id="courseInput" name="courseField">
-                        <option value="" disabled selected>{{ ticket.course }}</option>
-                        <option>Course 1</option>
-                        <option>Course 2</option>
-                        <option>Course 3</option>
-                        <option>Course 4</option>
-                        <option>Course 5</option>
+                    <select class="form-select" id="course_select" name="courseField">
+                        <option value="{{ ticket.course }}" selected>{{ Course.query.get(ticket.course).course_name }}</option>
+                        {% for course in Course.query.filter(Course.id != ticket.course) %}
+                            <option value="{{ course.id }}" value="{{ course.id }}">{{ course.course_name }}</option>
+                        {% endfor %}
                     </select>
 
                     <strong>Section</strong>
-                    <select class="form-control" id="sectionInput" name="sectionField">
-                        <option value="" disabled selected>{{ ticket.section }}</option>
-                        <option>Section 1</option>
-                        <option>Section 2</option>
-                        <option>Section 3</option>
-                        <option>Section 4</option>
-                        <option>Section 5</option>
+                    <select class="form-select" id="section_select" name="sectionField" required>
+                        <option value disabled hidden>Select Section</option>
+                        <option id="{{ ticket.course }}" value="{{ ticket.section }}" selected disabled>{{ Section.query.get(ticket.section).section_number }}</option>
+                        {% for section in Section.query.filter(Section.id != ticket.section) %}
+                            <option id="{{ section.course_id }}" value="{{ section.id }}">{{ section.section_number }}</option>
+                        {% endfor %}
                     </select>
 
                     <strong>Assignment Name</strong>
@@ -207,4 +204,8 @@
 </div>
 {% endfor %}
 
+{% endblock %}
+
+{% block scripts %}
+    <script src="{{ url_for('static', filename='js/course_selector.js') }}"></script>
 {% endblock %}

--- a/portal/app/templates/view_tickets.html
+++ b/portal/app/templates/view_tickets.html
@@ -18,7 +18,7 @@
                     <div class="card-header" style="text-align:left;">
                         <h3>{{ ticket.student_name }}</h3>
                         {{ ticket.student_email }} <br>
-                        {{ ticket.course }}:{{ticket.section}}
+                        {{ ticket.get_course().course_name }}:{{ticket.get_section().section_number}}
                     </div>
                     <div class="card-body">
                         <p class="card-text" style="text-align:left;">
@@ -56,7 +56,7 @@
                     <div class="card-header" style="text-align:left;">
                         <h3>{{ ticket.student_name }}</h3>
                         {{ ticket.student_email }} <br>
-                        {{ ticket.course }}:{{ticket.section}}
+                        {{ ticket.get_course().course_name }}:{{ticket.get_section().section_number}}
                     </div>
                     <div class="card-body">
                         <p class="card-text" style="text-align:left;">
@@ -92,7 +92,7 @@
                     <div class="card-header" style="text-align:left;">
                         <h3>{{ ticket.student_name }}</h3>
                         {{ ticket.student_email }} <br>
-                        {{ ticket.course }}:{{ticket.section}}
+                        {{ ticket.get_course().course_name }}:{{ticket.get_section().section_number}}
                     </div>
                     <div class="card-body">
                         <p class="card-text" style="text-align:left;">
@@ -142,7 +142,7 @@
 
                     <strong>Course</strong>
                     <select class="form-select" id="course_select" name="courseField">
-                        <option value="{{ ticket.course }}" selected>{{ Course.query.get(ticket.course).course_name }}</option>
+                        <option value="{{ ticket.course }}" selected>{{ ticket.get_course().course_name }}</option>
                         {% for course in Course.query.filter(Course.id != ticket.course) %}
                             <option value="{{ course.id }}" value="{{ course.id }}">{{ course.course_name }}</option>
                         {% endfor %}
@@ -151,7 +151,7 @@
                     <strong>Section</strong>
                     <select class="form-select" id="section_select" name="sectionField" required>
                         <option value disabled hidden>Select Section</option>
-                        <option id="{{ ticket.course }}" value="{{ ticket.section }}" selected disabled>{{ Section.query.get(ticket.section).section_number }}</option>
+                        <option id="{{ ticket.course }}" value="{{ ticket.section }}" selected disabled>{{ ticket.get_section().section_number }}</option>
                         {% for section in Section.query.filter(Section.id != ticket.section) %}
                             <option id="{{ section.course_id }}" value="{{ section.id }}">{{ section.section_number }}</option>
                         {% endfor %}

--- a/portal/tests/conftest.py
+++ b/portal/tests/conftest.py
@@ -4,6 +4,9 @@ from flask import Flask
 
 from app.model import db
 from app.model import Permission
+from app.model import Course
+from app.model import Section
+from app.model import SectionMode
 from app.model import ProblemType
 
 from app.blueprints.admin import create_pseudo_super_user
@@ -41,7 +44,7 @@ def app():
     app = create_app()
 
     # NOTE: Here we add some default configs
-    # TODO: This will be replaced by some default config for the app
+    # TODO: This will need to be replaced by some default config or fixture for the app
     #       We should make the config available to the tests!
     #
     with app.app_context():
@@ -53,13 +56,13 @@ def app():
     yield app
 
 @pytest.fixture
-def client(app : Flask):
+def client(app: Flask):
     """Provides a test flask client for sending http requests to the application."""
 
     return app.test_client()
 
 @pytest.fixture
-def create_auth_client(app : Flask):
+def create_auth_client(app: Flask):
     """Provides an factory function for creating an authenticated client."""
 
     # This factory function sets some parameters we can choose in the test
@@ -121,6 +124,28 @@ def admin_client(create_super_user):
 @pytest.fixture
 def owner_client(create_super_user):
     return create_super_user(email='owner@email.com', permission=Permission.Owner)
+
+@pytest.fixture
+def mock_courses(app: Flask):
+    def _factory(*courses: list[Course]):
+        with app.app_context():
+            for course in courses:
+                db.session.add(course)
+
+            db.session.commit()
+
+    return _factory
+
+@pytest.fixture
+def mock_sections(app: Flask):
+    def _factory(*sections: list[Section]):
+        with app.app_context():
+            for section in sections:
+                db.session.add(section)
+
+            db.session.commit()
+
+    return _factory
 
 @pytest.fixture(scope="session", autouse=True)
 def cleanup(request):

--- a/portal/tests/test_create_ticket.py
+++ b/portal/tests/test_create_ticket.py
@@ -1,6 +1,9 @@
 from flask import Flask
 from flask.testing import FlaskClient
 
+from app.model import Course
+from app.model import Section
+from app.model import SectionMode
 from app.model import Ticket
 from app.model import Mode
 
@@ -8,13 +11,15 @@ import pytest
 
 # TODO: Need to test more invalid input (e.g. long strings, etc.) break the database!
 
-def test_create_ticket_post_with_no_auth(create_auth_client, app: Flask):
+def test_create_ticket_post_with_no_auth(create_auth_client, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
 
     auth_client = create_auth_client(name='John Doe', email='test@test.email')
 
     test_form_data = {
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -29,8 +34,8 @@ def test_create_ticket_post_with_no_auth(create_auth_client, app: Flask):
         ticket: Ticket = Ticket.query.first()
         assert ticket.student_email == 'test@test.email'
         assert ticket.student_name == 'John Doe'
-        assert ticket.course == 'course1'
-        assert ticket.section == 'section1'
+        assert ticket.course == '1'
+        assert ticket.section == '1'
         assert ticket.assignment_name == 'assignment1'
         assert ticket.specific_question == 'This is my question?'
         assert ticket.problem_type == 1
@@ -49,34 +54,36 @@ def test_create_ticket_post_with_no_auth(create_auth_client, app: Flask):
     assert b'href="/"' in response.data
 
 def test_create_ticket_no_data(auth_client: FlaskClient, app: Flask):
-    response = auth_client.post('/create-ticket', data={})
+    response = auth_client.post('/create-ticket')
 
-    # We accept tickets as long as they have name and email for now
     with app.app_context():
-        assert Ticket.query.count() == 1
+        assert Ticket.query.count() == 0
 
     with auth_client.session_transaction() as session:
         flashes = session['_flashes']
         assert len(flashes) == 1
 
         (category, message) = flashes[0]
-        assert category == 'success'
-        assert message == 'Ticket created successfully!'
+        assert category == 'error'
+        assert message == 'Could not submit ticket, invalid data'
 
     # Expect redirect back to create ticket page
     assert '302' in response.status
-    assert b'href="/"' in response.data
+    assert b'href="/create-ticket"' in response.data
 
 @pytest.fixture
-def create_ticket_with_invalid_data(auth_client: FlaskClient, app: Flask):
+def create_ticket_with_invalid_data(auth_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     test_form_data = {
-            'course':'course1',
-            'section':'section1',
-            'assignment':'assignment1',
-            'question':'This is my question?',
-            'problem':'1',
-            'mode': Mode.InPerson.value
-        }
+        'course':'1',
+        'section':'1',
+        'assignment':'assignment1',
+        'question':'This is my question?',
+        'problem':'1',
+        'mode': Mode.InPerson.value
+    }
 
     def _factory(**kwargs):
         for key, val in kwargs.items():

--- a/portal/tests/test_create_ticket_guest.py
+++ b/portal/tests/test_create_ticket_guest.py
@@ -3,16 +3,21 @@ from flask.testing import FlaskClient
 
 from app.model import Ticket
 from app.model import Mode
+from app.model import Course
+from app.model import Section
+from app.model import SectionMode
 
 import pytest
 
-def test_create_ticket_post_with_no_auth(client: FlaskClient, app: Flask):
+def test_create_ticket_post_with_no_auth(client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
 
     test_form_data = {
         'email':'test@test.email',
         'fullname':'John Doe',
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -27,8 +32,8 @@ def test_create_ticket_post_with_no_auth(client: FlaskClient, app: Flask):
         ticket: Ticket = Ticket.query.first()
         assert ticket.student_email == 'test@test.email'
         assert ticket.student_name == 'John Doe'
-        assert ticket.course == 'course1'
-        assert ticket.section == 'section1'
+        assert ticket.course == '1'
+        assert ticket.section == '1'
         assert ticket.assignment_name == 'assignment1'
         assert ticket.specific_question == 'This is my question?'
         assert ticket.problem_type == 1
@@ -47,7 +52,7 @@ def test_create_ticket_post_with_no_auth(client: FlaskClient, app: Flask):
     assert b'href="/"' in response.data
 
 def test_create_ticket_no_data(client: FlaskClient, app: Flask):
-    response = client.post('/create-ticket', data={})
+    response = client.post('/create-ticket')
 
     with app.app_context():
         assert Ticket.query.count() == 0
@@ -65,17 +70,20 @@ def test_create_ticket_no_data(client: FlaskClient, app: Flask):
     assert b'href="/create-ticket"' in response.data
 
 @pytest.fixture
-def create_ticket_with_invalid_data(client: FlaskClient, app: Flask):
+def create_ticket_with_invalid_data(client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     test_form_data = {
-            'email':'test@test.email',
-            'fullname':'John Doe',
-            'course':'course1',
-            'section':'section1',
-            'assignment':'assignment1',
-            'question':'This is my question?',
-            'problem':'1',
-            'mode': Mode.InPerson.value
-        }
+        'email':'test@test.email',
+        'fullname':'John Doe',
+        'course':'1',
+        'section':'1',
+        'assignment':'assignment1',
+        'question':'This is my question?',
+        'problem':'1',
+        'mode': Mode.InPerson.value
+    }
 
     def _factory(**kwargs):
         for key, val in kwargs.items():

--- a/portal/tests/test_edit_ticket.py
+++ b/portal/tests/test_edit_ticket.py
@@ -1,5 +1,13 @@
 from flask import Flask
-from app.model import Ticket, Status, Mode, User
+
+from app.model import Mode
+from app.model import User
+from app.model import Ticket
+from app.model import Status
+from app.model import Course
+from app.model import Section
+from app.model import SectionMode
+
 from flask.testing import FlaskClient
 from app.extensions import db
 from app.model import Permission
@@ -34,11 +42,15 @@ def test_edit_no_data(tutor_client: FlaskClient):
     assert '302' in response.status
     assert b'href="/view-tickets"' in response.data
 
-def test_edit_course(tutor_client: FlaskClient, app: Flask):
+def test_edit_course(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False), Course('CSCI', '1620', 'Intro to CS 2', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None),\
+                  Section('851', 'Mon', None, None, SectionMode.TotallyOnline, '2', None, None))
+
     # make a ticket
     ticket1 = {
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -51,11 +63,11 @@ def test_edit_course(tutor_client: FlaskClient, app: Flask):
         assert '302' in response1.status
         assert Ticket.query.count() == 1
         testTicket = Ticket.query.one()
-        assert testTicket.course == "course1"
+        assert testTicket.course == '1'
 
     editData = {
         'ticketIDModal': '1',
-        'courseField': 'This is the updated course'
+        'courseField': '2'
     }
     response2 = tutor_client.post('/edit-ticket', data=editData)
 
@@ -63,13 +75,17 @@ def test_edit_course(tutor_client: FlaskClient, app: Flask):
     with app.app_context():
         assert '302' in response2.status
         testTicket = Ticket.query.one()
-        assert testTicket.course == "This is the updated course"
+        assert testTicket.course == '2'
 
-def test_edit_section(tutor_client: FlaskClient, app: Flask):
+def test_edit_section(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None),\
+                  Section('851', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -82,11 +98,11 @@ def test_edit_section(tutor_client: FlaskClient, app: Flask):
         assert '302' in response1.status
         assert Ticket.query.count() == 1
         testTicket = Ticket.query.one()
-        assert testTicket.section == "section1"
+        assert testTicket.section == '1'
 
     editData = {
         'ticketIDModal': '1',
-        'sectionField': 'NeW SeCtIoNNNNN'
+        'sectionField': '2'
     }
     response2 = tutor_client.post('/edit-ticket', data=editData)
 
@@ -94,13 +110,16 @@ def test_edit_section(tutor_client: FlaskClient, app: Flask):
     with app.app_context():
         assert '302' in response2.status
         testTicket = Ticket.query.one()
-        assert testTicket.section == "NeW SeCtIoNNNNN"
+        assert testTicket.section == '2'
 
-def test_edit_assignment(tutor_client: FlaskClient, app: Flask):
+def test_edit_assignment(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -127,11 +146,14 @@ def test_edit_assignment(tutor_client: FlaskClient, app: Flask):
         testTicket = Ticket.query.one()
         assert testTicket.assignment_name == "NeW Co0L Assignment"
 
-def test_edit_specific_question(tutor_client: FlaskClient, app: Flask):
+def test_edit_specific_question(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -158,11 +180,14 @@ def test_edit_specific_question(tutor_client: FlaskClient, app: Flask):
         testTicket = Ticket.query.one()
         assert testTicket.specific_question == "ThiS is ACCCtualy my QueStiIon...?"
 
-def test_edit_problem_type(tutor_client: FlaskClient, app: Flask):
+def test_edit_problem_type(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -189,11 +214,14 @@ def test_edit_problem_type(tutor_client: FlaskClient, app: Flask):
         testTicket = Ticket.query.one()
         assert testTicket.problem_type == 2
 
-def test_edit_tutor(tutor_client: FlaskClient, app: Flask):
+def test_edit_tutor(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -252,11 +280,14 @@ def test_edit_tutor(tutor_client: FlaskClient, app: Flask):
         assert testTicket.tutor_id == 2 # this is tutor2
         assert testTicket.user.name == "Timothy Smith"
 
-def test_edit_tutor_notes(tutor_client: FlaskClient, app: Flask):
+def test_edit_tutor_notes(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -283,11 +314,14 @@ def test_edit_tutor_notes(tutor_client: FlaskClient, app: Flask):
         testTicket = Ticket.query.one()
         assert testTicket.tutor_notes == "TTEESSTT Tutor N0T3s!!"
 
-def test_edit_was_successful(tutor_client: FlaskClient, app: Flask):
+def test_edit_was_successful(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -325,11 +359,15 @@ def test_edit_was_successful(tutor_client: FlaskClient, app: Flask):
         testTicket = Ticket.query.one()
         assert testTicket.successful_session == False
 
-def test_edit_multiple_attributes(tutor_client: FlaskClient, app: Flask):
+def test_edit_multiple_attributes(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False), Course('CSCI', '1620', 'Intro to CS 2', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None),\
+                  Section('851', 'Mon', None, None, SectionMode.TotallyOnline, '2', None, None))
+
     # make a ticket
     ticket1 = {
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -413,7 +451,7 @@ def test_edit_multiple_attributes(tutor_client: FlaskClient, app: Flask):
 
     editData = {
         'ticketIDModal': '1',
-        'courseField': 'This is the updated course'
+        'courseField': '2'
     }
     response2 = tutor_client.post('/edit-ticket', data=editData)
 
@@ -421,4 +459,4 @@ def test_edit_multiple_attributes(tutor_client: FlaskClient, app: Flask):
     with app.app_context():
         assert '302' in response2.status
         testTicket = Ticket.query.one()
-        assert testTicket.course == "This is the updated course"
+        assert testTicket.course == '2'

--- a/portal/tests/test_update_ticket.py
+++ b/portal/tests/test_update_ticket.py
@@ -1,17 +1,24 @@
 from flask import Flask
+
 from app.model import Ticket
 from app.model import Status
+from app.model import Course
+from app.model import Section
+from app.model import SectionMode
 from app.model import Mode
 
 from flask.testing import FlaskClient
 
-def test_claim_open_ticket(tutor_client: FlaskClient, app: Flask):
+def test_claim_open_ticket(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
         'email':'test@test.email',
         'fullname':'John Doe',
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -40,13 +47,16 @@ def test_claim_open_ticket(tutor_client: FlaskClient, app: Flask):
         assert Ticket.query.filter_by(status = Status.Open).count() != 1
         assert Ticket.query.filter_by(status = Status.Closed).count() != 1
 
-def test_close_claimed_ticket(tutor_client: FlaskClient, app: Flask):
+def test_close_claimed_ticket(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
         'email':'test@test.email',
         'fullname':'John Doe',
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -90,13 +100,16 @@ def test_close_claimed_ticket(tutor_client: FlaskClient, app: Flask):
         assert Ticket.query.filter_by(status = Status.Open).count() != 1
         assert Ticket.query.filter_by(status = Status.Claimed).count() != 1
 
-def test_reopen_closed_ticket(tutor_client: FlaskClient, app: Flask):
+def test_reopen_closed_ticket(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
         'email':'test@test.email',
         'fullname':'John Doe',
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',
@@ -156,13 +169,16 @@ def test_reopen_closed_ticket(tutor_client: FlaskClient, app: Flask):
         assert Ticket.query.filter_by(status = Status.Claimed).count() != 1
         assert Ticket.query.filter_by(status = Status.Closed).count() != 1
 
-def test_close_open_ticket(tutor_client: FlaskClient, app: Flask):
+def test_close_open_ticket(tutor_client: FlaskClient, mock_courses, mock_sections, app: Flask):
+    mock_courses(Course('CSCI', '1400', 'Intro to CS 1', False))
+    mock_sections(Section('850', 'Mon', None, None, SectionMode.TotallyOnline, '1', None, None))
+
     # make a ticket
     ticket1 = {
         'email':'test@test.email',
         'fullname':'John Doe',
-        'course':'course1',
-        'section':'section1',
+        'course':'1',
+        'section':'1',
         'assignment':'assignment1',
         'question':'This is my question?',
         'problem':'1',


### PR DESCRIPTION
Integrated courses and sections with the frontend. Users can now create tickets using the courses and sections existing in the DB. Frontend will only show sections relevant to the selected course, backend will ensure the section matches with the course. Tutors can also edit these fields in the view tickets page.